### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/piApp/src/drvPIC630.cc
+++ b/piApp/src/drvPIC630.cc
@@ -63,7 +63,7 @@ volatile int PIC630_current[9];  /* current settings per axis */
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static void start_status(int);
 static int set_status(int, int);
 static long report(int);
@@ -287,7 +287,7 @@ static int set_status(int card, int signal)
 /* send a message to the PIC630 board                 */
 /* send_mess()                                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, const char *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char buff[BUFF_SIZE];
     char inp_buff[BUFF_SIZE];

--- a/piApp/src/drvPIC662.cc
+++ b/piApp/src/drvPIC662.cc
@@ -78,14 +78,14 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIC662_num_cards = 0;
-static char *PIC662_axis[4] = {"1", "2", "3", "4"};
+static const char *PIC662_axis[4] = {"1", "2", "3", "4"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -231,7 +231,7 @@ static int set_status(int card, int signal)
     nodeptr = motor_info->motor_motion;
     status.All = motor_info->status.All;
 
-    send_mess(card, GET_STATUS, (char*) NULL);
+    send_mess(card, GET_STATUS, NULL);
     comm_status = recv_mess(card, buff, 1);
     if (comm_status == 0)
     {
@@ -270,7 +270,7 @@ static int set_status(int card, int signal)
      * Skip to substring for this motor, convert to double
      */
 
-    send_mess(card, GET_POS, (char*) NULL);
+    send_mess(card, GET_POS, NULL);
     recv_mess(card, buff, 1);
 
     motorData = NINT (atof(buff) / cntrl->drive_resolution);
@@ -339,7 +339,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -353,7 +353,7 @@ exit:
 /* send a message to the PIC662 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIC662controller *cntrl;
@@ -538,7 +538,7 @@ static int motor_init()
 
 	    do
 	    {
-		send_mess(card_index, GET_IDENT, (char*) NULL);
+		send_mess(card_index, GET_IDENT, NULL);
 		status = recv_mess(card_index, buff, 1);
                 retry++;
 	    } while (status == 0 && retry < 3);

--- a/piApp/src/drvPIC663.cc
+++ b/piApp/src/drvPIC663.cc
@@ -58,7 +58,7 @@ int PIC663_num_cards = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -214,7 +214,7 @@ static int set_status(int card, int signal)
     if (cntrl->status != NORMAL)
 	charcnt = recv_mess(card, buff, FLUSH);
 
-    send_mess(card, "TS", (char*) NULL);		/*  Tell Status */
+    send_mess(card, "TS", NULL);		/*  Tell Status */
     charcnt = recv_mess(card, buff, 1);
     if (charcnt > 9)
 	convert_cnt = sscanf(buff, "S:%2hx %2hx %2hx\n", 
@@ -255,7 +255,7 @@ static int set_status(int card, int signal)
     minusLS = mstat2.Bits.lo_limit ? 0 : 1;
 
    /* Parse motor position */
-    send_mess(card, "TP", (char*) NULL);  /*  Tell Position */
+    send_mess(card, "TP", NULL);  /*  Tell Position */
     recv_mess(card, buff, 1);
     motorData = NINT(atof(&buff[2]));
      
@@ -309,7 +309,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -323,7 +323,7 @@ exit:
 /* send a message to the PIC663 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIC663controller *cntrl;
@@ -521,7 +521,7 @@ static int motor_init()
 	    do
 	    {
                 sprintf(buff,"\001%1XVE", cntrl->asyn_address);
-                send_mess(card_index, buff, (char*) NULL);
+                send_mess(card_index, buff, NULL);
 		status = recv_mess(card_index, buff, 1);
 		retry++;
 	    } while (status == 0 && retry < 3);

--- a/piApp/src/drvPIC844.cc
+++ b/piApp/src/drvPIC844.cc
@@ -86,14 +86,14 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIC844_num_cards = 0;
-static char *PIC844_axis[4] = {"1", "2", "3", "4"};
+static const char *PIC844_axis[4] = {"1", "2", "3", "4"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -264,7 +264,7 @@ static int set_status(int card, int signal)
     cntrl->status = NORMAL;
     status.Bits.CNTRL_COMM_ERR = 0;
 
-    send_mess(card, "MOT:COND?", (char*) NULL);
+    send_mess(card, "MOT:COND?", NULL);
     recv_mess(card, buff, 1);
 
     mstat.All = atoi(&buff[0]);
@@ -295,7 +295,7 @@ static int set_status(int card, int signal)
      * Skip to substring for this motor, convert to double
      */
 
-    send_mess(card, "CURR:TPOS?", (char*) NULL);
+    send_mess(card, "CURR:TPOS?", NULL);
     recv_mess(card, buff, 1);
 
     motorData = atof(buff);
@@ -364,7 +364,7 @@ static int set_status(int card, int signal)
     status.Bits.EA_SLIP_STALL = 0;
     status.Bits.EA_HOME	      = 0;
 
-    send_mess(card, "AXIS:POS?", (char*) NULL);
+    send_mess(card, "AXIS:POS?", NULL);
     recv_mess(card, buff, 1);
     motorData = atof(buff);
     motor_info->encoder_position = (epicsInt32) motorData;
@@ -387,7 +387,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -401,7 +401,7 @@ exit:
 /* send a message to the PIC844 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIC844controller *cntrl;
@@ -596,7 +596,7 @@ static int motor_init()
 
 	    do
 	    {
-		send_mess(card_index, GET_IDENT, (char*) NULL);
+		send_mess(card_index, GET_IDENT, NULL);
 		status = recv_mess(card_index, buff, 1);
                 retry++;
 	    } while (status == 0 && retry < 3);

--- a/piApp/src/drvPIC848.cc
+++ b/piApp/src/drvPIC848.cc
@@ -75,7 +75,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIC848_num_cards = 0;
-static char *PIC848_axis[4] = {"A", "B", "C", "D"};
+static const char *PIC848_axis[4] = {"A", "B", "C", "D"};
 static volatile int motionTO = 10;
 
 /* Local data required for every driver; see "motordrvComCode.h" */
@@ -84,7 +84,7 @@ static volatile int motionTO = 10;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -341,7 +341,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -355,7 +355,7 @@ exit:
 /* send a message to the PIC848 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIC848controller *cntrl;
@@ -548,7 +548,7 @@ static int motor_init()
 
 	    do
 	    {
-		send_mess(card_index, GET_IDENT, (char*) NULL);
+		send_mess(card_index, GET_IDENT, NULL);
 		status = recv_mess(card_index, buff, 1);
 		retry++;
 	    } while (status == 0 && retry < 3);

--- a/piApp/src/drvPIC862.cc
+++ b/piApp/src/drvPIC862.cc
@@ -67,7 +67,7 @@ int PIC862_num_cards = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -225,7 +225,7 @@ static int set_status(int card, int signal)
     if (cntrl->status != NORMAL)
 	charcnt = recv_mess(card, buff, FLUSH);
 
-    send_mess(card, "TS", (char*) NULL);		/*  Tell Status */
+    send_mess(card, "TS", NULL);		/*  Tell Status */
     charcnt = recv_mess(card, buff, 1);
     if (charcnt > 18)
 	convert_cnt = sscanf(buff, "S:%2hx %2hx %2hx %2hx %2hx %2hx\n", 
@@ -281,7 +281,7 @@ static int set_status(int card, int signal)
 
 
    /* Parse motor position */
-    send_mess(card, "TP", (char*) NULL);  /*  Tell Position */
+    send_mess(card, "TP", NULL);  /*  Tell Position */
     recv_mess(card, buff, 1);
     motorData = NINT(atof(&buff[2]));
      
@@ -335,7 +335,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -349,7 +349,7 @@ exit:
 /* send a message to the PIC862 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIC862controller *cntrl;
@@ -547,7 +547,7 @@ static int motor_init()
 	    do
 	    {
                 sprintf(buff,"\001%1XVE", cntrl->asyn_address);
-                send_mess(card_index, buff, (char*) NULL);
+                send_mess(card_index, buff, NULL);
 		status = recv_mess(card_index, buff, 1);
 		retry++;
 	    } while (status == 0 && retry < 3);

--- a/piApp/src/drvPIE516.cc
+++ b/piApp/src/drvPIE516.cc
@@ -82,7 +82,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIE516_num_cards = 0;
-static char *PIE516_axis[] = {"A", "B", "C"};
+static const char *PIE516_axis[] = {"A", "B", "C"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
@@ -90,7 +90,7 @@ static char *PIE516_axis[] = {"A", "B", "C"};
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -243,14 +243,14 @@ static int set_status(int card, int signal)
     recv_mess(card, buff, FLUSH);
 
     readOK = false;   
-    send_mess(card, READ_ONLINE, (char*) NULL);
+    send_mess(card, READ_ONLINE, NULL);
     if (recv_mess(card, buff, 1) && sscanf(buff, "%d", &online_status))
       {
 	if (!online_status)
 	  {
 	    /* Assume Controller Reboot - Set ONLINE and Velocity Control ON */
-	    send_mess(card, SET_ONLINE, (char*) NULL);
-	    send_mess(card, SET_VELCTRL, (char*) NULL);
+	    send_mess(card, SET_ONLINE, NULL);
+	    send_mess(card, SET_VELCTRL, NULL);
 	  }
 
 	send_mess(card, READ_ONTARGET, PIE516_axis[signal]);
@@ -367,7 +367,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -381,7 +381,7 @@ exit:
 /* send a message to the PIE516 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     char *pbuff;
@@ -585,15 +585,15 @@ static int motor_init()
 	    {
 	      online = false;
 	      /* Set Controller to ONLINE mode */
-	      send_mess(card_index, SET_ONLINE, (char*) NULL);
-	      send_mess(card_index, READ_ONLINE, (char*) NULL);
+	      send_mess(card_index, SET_ONLINE, NULL);
+	      send_mess(card_index, READ_ONLINE, NULL);
 	      if ((status = recv_mess(card_index, buff, 1)))
 		online = (atoi(buff)==1) ? true : false;
 	      else
 		retry++;
 	    } while (online == false && retry < 3);
 
-	    send_mess(card_index, GET_IDENT, (char*) NULL);
+	    send_mess(card_index, GET_IDENT, NULL);
 	    status = recv_mess(card_index, buff, 1);
 	    
 	    /* Parse out E516 revision (2 decimal places) and convert to int */
@@ -626,7 +626,7 @@ static int motor_init()
 	    brdptr->total_axis = total_axis;
 
 	    /* Turn ON velocity control mode  - All axis */
-	    send_mess(card_index, SET_VELCTRL, (char*) NULL);
+	    send_mess(card_index, SET_VELCTRL, NULL);
 
 	    for (motor_index = 0; motor_index < total_axis; motor_index++)
 	    {

--- a/piApp/src/drvPIE517.cc
+++ b/piApp/src/drvPIE517.cc
@@ -90,7 +90,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIE517_num_cards = 0;
-static char *PIE517_axis[] = {"1 ", "2 ", "3 "}; //{"A", "B", "C"};
+static const char *PIE517_axis[] = {"1 ", "2 ", "3 "}; //{"A", "B", "C"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
@@ -98,7 +98,7 @@ static char *PIE517_axis[] = {"1 ", "2 ", "3 "}; //{"A", "B", "C"};
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -374,7 +374,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -388,7 +388,7 @@ exit:
 /* send a message to the PIE517 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     char *pbuff;
@@ -597,15 +597,15 @@ static int motor_init()
 	    //{
 	    //  online = false;
 	    //  /* Set Controller to ONLINE mode */
-	    //  send_mess(card_index, SET_ONLINE, (char*) NULL);
-	    //  send_mess(card_index, READ_ONLINE, (char*) NULL);
+	    //  send_mess(card_index, SET_ONLINE, NULL);
+	    //  send_mess(card_index, READ_ONLINE, NULL);
 	    //  if ((status = recv_mess(card_index, buff, 1)))
 		//online = (atoi(buff)==1) ? true : false;
 	    //  else
 		//retry++;
 	    //} while (online == false && retry < 3);
 
-	    //send_mess(card_index, GET_IDENT, (char*) NULL);
+	    //send_mess(card_index, GET_IDENT, NULL);
 	    //status = recv_mess(card_index, buff, 1);
 	    
 	    /* Parse out E517 revision (2 decimal places) and convert to int */
@@ -638,7 +638,7 @@ static int motor_init()
 	    brdptr->total_axis = total_axis;
 
 	    /* Turn ON velocity control mode  - All axis */
-	    //send_mess(card_index, SET_VELCTRL, (char*) NULL);
+	    //send_mess(card_index, SET_VELCTRL, NULL);
 
 	    for (motor_index = 0; motor_index < total_axis; motor_index++)
 	    {

--- a/piApp/src/drvPIE710.cc
+++ b/piApp/src/drvPIE710.cc
@@ -74,7 +74,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIE710_num_cards = 0;
-static char *PIE710_axis[] = {"1", "2", "3", "4", "5", "6"};
+static const char *PIE710_axis[] = {"1", "2", "3", "4", "5", "6"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
@@ -82,7 +82,7 @@ static char *PIE710_axis[] = {"1", "2", "3", "4", "5", "6"};
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -351,7 +351,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -365,7 +365,7 @@ exit:
 /* send a message to the PIE710 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     struct PIE710controller *cntrl;
@@ -560,7 +560,7 @@ static int motor_init()
 
 	    do
 	    {
-		send_mess(card_index, GET_IDENT, (char*) NULL);
+		send_mess(card_index, GET_IDENT, NULL);
 		status = recv_mess(card_index, buff[0], 1);
 
 		/* Parse out E710 revision (3 decimal places) and convert to int */

--- a/piApp/src/drvPIE816.cc
+++ b/piApp/src/drvPIE816.cc
@@ -90,7 +90,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int PIE816_num_cards = 0;
-static char *PIE816_axis[] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
+static const char *PIE816_axis[] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
                                "K","L"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
@@ -99,7 +99,7 @@ static char *PIE816_axis[] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, char const *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static int set_status(int, int);
 static long report(int);
 static long init();
@@ -252,14 +252,14 @@ static int set_status(int card, int signal)
     recv_mess(card, buff, FLUSH);
 
     readOK = false;   
-    //send_mess(card, READ_ONLINE, (char*) NULL);
+    //send_mess(card, READ_ONLINE, NULL);
 /*    if (recv_mess(card, buff, 1) && sscanf(buff, "%d", &online_status))
       {
 	if (!online_status)
 	  {
 	    *//* Assume Controller Reboot - Set ONLINE and Velocity Control ON */
-	    /*send_mess(card, SET_ONLINE, (char*) NULL);
-	    send_mess(card, SET_VELCTRL, (char*) NULL);
+	    /*send_mess(card, SET_ONLINE, NULL);
+	    send_mess(card, SET_VELCTRL, NULL);
 	  }
 */
 	send_mess(card, READ_ONTARGET, PIE816_axis[signal]);
@@ -377,7 +377,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
 	strcpy(buff, nodeptr->postmsgptr);
-	send_mess(card, buff, (char*) NULL);
+	send_mess(card, buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -391,7 +391,7 @@ exit:
 /* send a message to the PIE816 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     char local_buff[MAX_MSG_SIZE];
     char *pbuff;
@@ -597,15 +597,15 @@ static int motor_init()
 	      online = false;
 */
 	      /* Set Controller to ONLINE mode */
-/*	      send_mess(card_index, SET_ONLINE, (char*) NULL);
-	      send_mess(card_index, READ_ONLINE, (char*) NULL);
+/*	      send_mess(card_index, SET_ONLINE, NULL);
+	      send_mess(card_index, READ_ONLINE, NULL);
 	      if ((status = recv_mess(card_index, buff, 1)))
 		online = (atoi(buff)==1) ? true : false;
 	      else
 		retry++;
 	    } while (online == false && retry < 3);
 */
-	    send_mess(card_index, GET_IDENT, (char*) NULL);
+	    send_mess(card_index, GET_IDENT, NULL);
 	    status = recv_mess(card_index, buff, 1);
 	    
 	    /* Parse out E816 revision (2 decimal places) and convert to int */
@@ -639,7 +639,7 @@ static int motor_init()
 	    brdptr->total_axis = total_axis;
 
 	    /* Turn ON velocity control mode  - All axis */
-	    /*send_mess(card_index, SET_VELCTRL, (char*) NULL);*/
+	    /*send_mess(card_index, SET_VELCTRL, NULL);*/
 
 	    for (motor_index = 0; motor_index < total_axis; motor_index++)
 	    {


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.