### PR TITLE
Remove uses of deprecated `register` keyword

### DIFF
--- a/piApp/src/drvPIC630.cc
+++ b/piApp/src/drvPIC630.cc
@@ -174,7 +174,7 @@ static int set_status(int card, int signal)
 {
     struct PIC630Controller *cntrl;
     struct mess_node *nodeptr;
-    register struct mess_info *motor_info;
+    struct mess_info *motor_info;
     char command[BUFF_SIZE];
     char response[BUFF_SIZE];
     char cStatus;

--- a/piApp/src/drvPIC662.cc
+++ b/piApp/src/drvPIC662.cc
@@ -215,7 +215,7 @@ static int set_status(int card, int signal)
 {
     struct PIC662controller *cntrl;
     struct mess_node *nodeptr;
-    register struct mess_info *motor_info;
+    struct mess_info *motor_info;
     /* Message parsing variables */
     char buff[BUFF_SIZE];
     E662_ESR_REG mstat;

--- a/piApp/src/drvPIC844.cc
+++ b/piApp/src/drvPIC844.cc
@@ -223,7 +223,7 @@ static int set_status(int card, int signal)
 {
     struct PIC844controller *cntrl;
     struct mess_node *nodeptr;
-    register struct mess_info *motor_info;
+    struct mess_info *motor_info;
     /* Message parsing variables */
     char buff[BUFF_SIZE];
     C844_Cond_Reg mstat;


### PR DESCRIPTION
This keyword was deprecated in C++11 and removed in C++17. clang 16 defaults to C++17 and produces errors when compiling this module.